### PR TITLE
Allow grid focus to be hidden

### DIFF
--- a/c3js-directive.js
+++ b/c3js-directive.js
@@ -156,6 +156,13 @@ angular.module('gridshore.c3js.chart', [])
 		$scope.colors = colors;
 	};
 
+	this.hideGridFocus = function() {
+		if ($scope.grid == null) {
+			$scope.grid = {};
+		}
+		$scope.grid["focus"] = {"show": false};
+	};
+
 	function addColumnProperties(id, columnType, columnName, columnColor) {
 		if (columnType !== undefined) {
 			$scope.types[id]=columnType;
@@ -370,6 +377,10 @@ angular.module('gridshore.c3js.chart', [])
 		var showY2 = attrs.showY2;
 		if (showY2 && showY2 === "true") {
 			chartCtrl.addGrid("y2");
+		}
+		var showFocus = attrs.showFocus;
+		if (showFocus && showFocus === "false") {
+			chartCtrl.hideGridFocus();
 		}
 	};
 


### PR DESCRIPTION
This PR will allow the grid focus to be hidden through the DSL.

```html
<c3chart bindto-id="line-chart">
  <chart-column column-id="Data 1" 
                column-values="30,200,100,400,150,250,50"
                column-type="line"/>
  <chart-grid show-focus="false"/>
</c3chart>
```