### PR TITLE
Cleanup charts on destroy

### DIFF
--- a/c3js-directive.js
+++ b/c3js-directive.js
@@ -1,20 +1,27 @@
 angular.module('gridshore.c3js.chart', [])
 .controller('ChartController',['$scope', function($scope) {
-	$scope.chart = null;
-	$scope.columns = [];
-	$scope.types = {};
-	$scope.axis = {};
-	$scope.axes = {};
-	$scope.xValues= null;
-	$scope.xTick = null;
-	$scope.names = null;
-	$scope.colors = null;
-	$scope.grid = null;
-	$scope.legend = null;
-	$scope.tooltip = null;
-	$scope.chartSize = null;
-	$scope.colors = null;
-	$scope.jsonKeys = null;
+
+	function resetVars() {
+		$scope.chart = null;
+		$scope.columns = [];
+		$scope.types = {};
+		$scope.axis = {};
+		$scope.axes = {};
+		$scope.padding = null;
+		$scope.xValues= null;
+		$scope.xsValues = null;
+		$scope.xTick = null;
+		$scope.names = null;
+		$scope.colors = null;
+		$scope.grid = null;
+		$scope.legend = null;
+		$scope.tooltip = null;
+		$scope.chartSize = null;
+		$scope.colors = null;
+		$scope.jsonKeys = null;
+	};
+
+	resetVars();
 
 	this.showGraph = function() {
 		var config = {};			
@@ -71,8 +78,16 @@ angular.module('gridshore.c3js.chart', [])
 				loadChartData();
 			});
 		} else {
-			$scope.chart = c3.generate($scope.config);				
+			$scope.chart = c3.generate($scope.config);
+
 		}
+
+		$scope.$on('$destroy', function() {
+			if (angular.isDefined($scope.chart)) {
+				$scope.chart = $scope.chart.destroy();
+				resetVars();
+			}
+		});
 	};
 
 	this.addColumn = function(column,columnType,columnName,columnColor) {


### PR DESCRIPTION
I've noticed my pages getting very slow after I'd visit a page with about 8 charts on them. After some investigation I found out the charts wouldn't get garbage collected.

This PR will cleanup the chart and all used vars. Also upgrading to the latest version of C3 (0.4.10) seemed to increase performance.